### PR TITLE
Add elixir wrapper for business-email-validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/elixir/_build
+**/elixir/.elixir_ls
+**/elixir/deps

--- a/dist/elixir/README.md
+++ b/dist/elixir/README.md
@@ -1,0 +1,13 @@
+# BusinessEmailValidator
+
+This library contains a custom and minimal wrapper for ELixir, to use the BusinessEmailValidator dataset directly.
+
+Important to note is that the dataset is read and parsed in compilation time, improving the running time by a huge margin.
+
+## Installation
+
+This package is **not** available in Hex. We suggest you to copy the JSON file from the `src` folder on this project's root, and copy this model implementation.
+
+## Author 🧙‍♂️
+
+- RafaAudibert ➡️ [www.rafaaudibert.dev](www.rafaaudibert.dev)

--- a/dist/elixir/lib/business_email_validator.ex
+++ b/dist/elixir/lib/business_email_validator.ex
@@ -1,0 +1,31 @@
+defmodule BusinessEmailValidator do
+  @moduledoc """
+  This class implement the core logic for the `businessEmailValidator` library.
+
+  It loads the dataset of valid emails, and identifies if the email
+  is valid or not through the `is_valid` method
+  """
+
+  @filename "../../src/freeEmailService.json"
+  @external_resource @filename
+  @data @filename |> File.read!() |> Jason.decode!() |> Map.keys()
+
+  @spec is_valid(String.t()) :: boolean
+  @doc """
+  Main (and only) function of the library, with a thin API allowing you to check
+  if an email is valid or not, based on a simple heuristic of checking against a
+  manually curated dataset of invalid domains.
+
+  ## Examples
+
+      iex> BusinessEmailValidator.is_valid("email@customdomain.com")
+      true
+
+      iex> BusinessEmailValidator.is_valid("email@stopdropandroll.com")
+      false
+  """
+  def is_valid(email) do
+    domain = String.split(email, "@", parts: 2) |> List.last()
+    !Enum.member?(@data, domain)
+  end
+end

--- a/dist/elixir/mix.exs
+++ b/dist/elixir/mix.exs
@@ -1,0 +1,25 @@
+defmodule BusinessEmailValidator.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :business_email_validator,
+      version: "0.1.0",
+      elixir: "~> 1.12",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [{:jason, "~> 1.2"}]
+  end
+end

--- a/dist/elixir/mix.lock
+++ b/dist/elixir/mix.lock
@@ -1,0 +1,3 @@
+%{
+  "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},
+}

--- a/dist/elixir/test/business_email_validator_test.exs
+++ b/dist/elixir/test/business_email_validator_test.exs
@@ -1,0 +1,4 @@
+defmodule BusinessEmailValidatorTest do
+  use ExUnit.Case, async: true
+  doctest BusinessEmailValidator
+end

--- a/dist/elixir/test/test_helper.exs
+++ b/dist/elixir/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
This PR adds an Elixir wrapper for the business-email-validator file.
As an interesting side note, the file is read and parsed in compilation time, with huge gains on running time.

Closes #43