### PR TITLE
title: Added a new line qwiklabs.com

### DIFF
--- a/src/freeEmailService.json
+++ b/src/freeEmailService.json
@@ -3275,5 +3275,6 @@
     "trashmail.net":true,
     "trashmail.org":true,
     "trashmail.ws":true,
-    "biyac.com": true
+    "biyac.com": true,
+    "qwiklabs.com":true
 }


### PR DESCRIPTION
description: qwiklabs.com is a business domain and hence, added into the freeEmailService.json